### PR TITLE
fix(calls): fix call popup dismissal, PeerJS cleanup, ULID-to-Guid migration, and eager search

### DIFF
--- a/backend/Eternity.Application/Calls/Commands/DeclineCallCommand.cs
+++ b/backend/Eternity.Application/Calls/Commands/DeclineCallCommand.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eternity.Application.Calls.Commands;
 
-public record DeclineCallCommand(string CallId) : IRequest<Result<DeclineCallResult>>;
+public record DeclineCallCommand(Guid CallId) : IRequest<Result<DeclineCallResult>>;
 
 public record DeclineCallResult(CallStatus CallStatus, bool CallEnded, List<Guid> ParticipantUserIds);
 
@@ -45,6 +45,6 @@ public class DeclineCallCommandHandler(IAppDbContext dbContext, ICurrentUser cur
 public class DeclineCallCommandValidator : AbstractValidator<DeclineCallCommand>
 {
     public DeclineCallCommandValidator() {
-        RuleFor(x => x.CallId).NotEmpty().MaximumLength(26);
+        RuleFor(x => x.CallId).NotEmpty();
     }
 }

--- a/backend/Eternity.Application/Calls/Commands/JoinCallCommand.cs
+++ b/backend/Eternity.Application/Calls/Commands/JoinCallCommand.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eternity.Application.Calls.Commands;
 
-public record JoinCallCommand(string CallId) : IRequest<Result<CallDto>>;
+public record JoinCallCommand(Guid CallId) : IRequest<Result<CallDto>>;
 
 public class JoinCallCommandHandler(IAppDbContext dbContext, ICurrentUser currentUser)
     : IRequestHandler<JoinCallCommand, Result<CallDto>>
@@ -88,6 +88,6 @@ public class JoinCallCommandHandler(IAppDbContext dbContext, ICurrentUser curren
 public class JoinCallCommandValidator : AbstractValidator<JoinCallCommand>
 {
     public JoinCallCommandValidator() {
-        RuleFor(x => x.CallId).NotEmpty().MaximumLength(26);
+        RuleFor(x => x.CallId).NotEmpty();
     }
 }

--- a/backend/Eternity.Application/Calls/Commands/LeaveCallCommand.cs
+++ b/backend/Eternity.Application/Calls/Commands/LeaveCallCommand.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eternity.Application.Calls.Commands;
 
-public record LeaveCallCommand(string CallId) : IRequest<Result<LeaveCallResult>>;
+public record LeaveCallCommand(Guid CallId) : IRequest<Result<LeaveCallResult>>;
 
 public record LeaveCallResult(CallStatus CallStatus, bool CallEnded, List<Guid> ParticipantUserIds);
 
@@ -41,6 +41,6 @@ public class LeaveCallCommandHandler(IAppDbContext dbContext, ICurrentUser curre
 public class LeaveCallCommandValidator : AbstractValidator<LeaveCallCommand>
 {
     public LeaveCallCommandValidator() {
-        RuleFor(x => x.CallId).NotEmpty().MaximumLength(26);
+        RuleFor(x => x.CallId).NotEmpty();
     }
 }

--- a/backend/Eternity.Application/Calls/Models/CallDtos.cs
+++ b/backend/Eternity.Application/Calls/Models/CallDtos.cs
@@ -5,7 +5,7 @@ namespace Eternity.Application.Calls.Models;
 
 public record CallParticipantDto
 {
-    public required string Id { get; init; }
+    public required Guid Id { get; init; }
     public required Guid UserId { get; init; }
     public required string Username { get; init; }
     public required string FullName { get; init; }
@@ -17,7 +17,7 @@ public record CallParticipantDto
 
 public record CallDto
 {
-    public required string Id { get; init; }
+    public required Guid Id { get; init; }
     public string? Name { get; init; }
     public required CallType Type { get; init; }
     public required CallStatus Status { get; init; }

--- a/backend/Eternity.Application/Calls/Queries/GetCallQuery.cs
+++ b/backend/Eternity.Application/Calls/Queries/GetCallQuery.cs
@@ -7,7 +7,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Eternity.Application.Calls.Queries;
 
-public record GetCallQuery(string CallId) : IRequest<Result<CallDto>>;
+public record GetCallQuery(Guid CallId) : IRequest<Result<CallDto>>;
 
 public class GetCallQueryHandler(IAppDbContext dbContext, ICurrentUser currentUser)
     : IRequestHandler<GetCallQuery, Result<CallDto>>
@@ -59,6 +59,6 @@ public class GetCallQueryHandler(IAppDbContext dbContext, ICurrentUser currentUs
 public class GetCallQueryValidator : AbstractValidator<GetCallQuery>
 {
     public GetCallQueryValidator() {
-        RuleFor(x => x.CallId).NotEmpty().MaximumLength(26);
+        RuleFor(x => x.CallId).NotEmpty();
     }
 }

--- a/backend/Eternity.Application/Common/Interfaces/ICallNotifier.cs
+++ b/backend/Eternity.Application/Common/Interfaces/ICallNotifier.cs
@@ -12,26 +12,26 @@ public interface ICallNotifier
     /// <summary>
     ///     Notify invitees about an incoming call via GeneralHub (so it works from any page).
     /// </summary>
-    Task NotifyIncomingCallAsync(string callId, CallParticipantDto initiator, CallType callType,
+    Task NotifyIncomingCallAsync(Guid callId, CallParticipantDto initiator, CallType callType,
         List<CallParticipantDto> participants, List<Guid> inviteeUserIds);
 
     /// <summary>
     ///     Notify participants in a call room that someone has joined.
     /// </summary>
-    Task NotifyParticipantJoinedAsync(string callId, Guid userId, string username, string fullName);
+    Task NotifyParticipantJoinedAsync(Guid callId, Guid userId, string username, string fullName);
 
     /// <summary>
     ///     Notify participants in a call room that someone has left.
     /// </summary>
-    Task NotifyParticipantLeftAsync(string callId, Guid userId);
+    Task NotifyParticipantLeftAsync(Guid callId, Guid userId);
 
     /// <summary>
     ///     Notify participants in a call room that someone declined.
     /// </summary>
-    Task NotifyCallDeclinedAsync(string callId, Guid userId);
+    Task NotifyCallDeclinedAsync(Guid callId, Guid userId);
 
     /// <summary>
     ///     Notify all participants that the call has ended (terminal status reached).
     /// </summary>
-    Task NotifyCallEndedAsync(string callId, string reason, List<Guid> participantUserIds);
+    Task NotifyCallEndedAsync(Guid callId, string reason, List<Guid> participantUserIds);
 }

--- a/backend/Eternity.Domain/Entities/Call.cs
+++ b/backend/Eternity.Domain/Entities/Call.cs
@@ -9,7 +9,7 @@ public class Call
     private Call() { }
 
     private Call(Guid initiatorId, CallType type, string? name) {
-        Id = Ulid.NewUlid().ToString();
+        Id = Guid.NewGuid();
         InitiatorId = initiatorId;
         Type = type;
         Name = name;
@@ -17,7 +17,7 @@ public class Call
         CreatedAt = DateTimeOffset.UtcNow;
     }
 
-    public string Id { get; } = null!;
+    public Guid Id { get; }
     public Guid InitiatorId { get; }
     public string? Name { get; private set; }
     public CallType Type { get; private set; }

--- a/backend/Eternity.Domain/Entities/CallParticipant.cs
+++ b/backend/Eternity.Domain/Entities/CallParticipant.cs
@@ -7,15 +7,15 @@ public class CallParticipant
     public const int MaxParticipantsPerCall = 5;
     private CallParticipant() { }
 
-    private CallParticipant(string callId, Guid userId, ParticipantStatus status) {
-        Id = Ulid.NewUlid().ToString();
+    private CallParticipant(Guid callId, Guid userId, ParticipantStatus status) {
+        Id = Guid.NewGuid();
         CallId = callId;
         UserId = userId;
         Status = status;
     }
 
-    public string Id { get; private set; } = null!;
-    public string CallId { get; private set; } = null!;
+    public Guid Id { get; private set; }
+    public Guid CallId { get; private set; }
     public Guid UserId { get; private set; }
     public ParticipantStatus Status { get; private set; }
     public DateTimeOffset? JoinedAt { get; private set; }
@@ -23,14 +23,14 @@ public class CallParticipant
     public Call Call { get; private set; } = null!;
     public UserAccount User { get; private set; } = null!;
 
-    public static CallParticipant CreateAsInitiator(string callId, Guid userId) {
+    public static CallParticipant CreateAsInitiator(Guid callId, Guid userId) {
         var participant = new CallParticipant(callId, userId, ParticipantStatus.Joined) {
             JoinedAt = DateTimeOffset.UtcNow
         };
         return participant;
     }
 
-    public static CallParticipant CreateAsInvitee(string callId, Guid userId) {
+    public static CallParticipant CreateAsInvitee(Guid callId, Guid userId) {
         return new CallParticipant(callId, userId, ParticipantStatus.Ringing);
     }
 

--- a/backend/Eternity.Domain/Eternity.Domain.csproj
+++ b/backend/Eternity.Domain/Eternity.Domain.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="MediatR" Version="14.1.0"/>
-        <PackageReference Include="Ulid" Version="1.4.1"/>
     </ItemGroup>
 
 </Project>

--- a/backend/Eternity.Infrastructure/Data/Configurations/CallConfiguration.cs
+++ b/backend/Eternity.Infrastructure/Data/Configurations/CallConfiguration.cs
@@ -9,7 +9,6 @@ public sealed class CallConfiguration : IEntityTypeConfiguration<Call>
     public void Configure(EntityTypeBuilder<Call> builder) {
         builder.HasKey(x => x.Id);
         builder.Property(x => x.Id)
-            .HasMaxLength(26) // ULID is 26 characters
             .IsRequired();
         builder.Property(x => x.InitiatorId).IsRequired();
         builder.Property(x => x.Name).HasMaxLength(256).IsRequired(false);

--- a/backend/Eternity.Infrastructure/Data/Configurations/CallParticipantConfiguration.cs
+++ b/backend/Eternity.Infrastructure/Data/Configurations/CallParticipantConfiguration.cs
@@ -9,9 +9,8 @@ public sealed class CallParticipantConfiguration : IEntityTypeConfiguration<Call
     public void Configure(EntityTypeBuilder<CallParticipant> builder) {
         builder.HasKey(x => x.Id);
         builder.Property(x => x.Id)
-            .HasMaxLength(26) // ULID is 26 characters
             .IsRequired();
-        builder.Property(x => x.CallId).HasMaxLength(26).IsRequired();
+        builder.Property(x => x.CallId).IsRequired();
         builder.Property(x => x.UserId).IsRequired();
         builder.Property(x => x.Status).IsRequired();
         builder.Property(x => x.JoinedAt).IsRequired(false);

--- a/backend/Eternity.Infrastructure/Migrations/20260413210852_MigrateCallIdsToGuid.Designer.cs
+++ b/backend/Eternity.Infrastructure/Migrations/20260413210852_MigrateCallIdsToGuid.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Eternity.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Eternity.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413210852_MigrateCallIdsToGuid")]
+    partial class MigrateCallIdsToGuid
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Eternity.Infrastructure/Migrations/20260413210852_MigrateCallIdsToGuid.cs
+++ b/backend/Eternity.Infrastructure/Migrations/20260413210852_MigrateCallIdsToGuid.cs
@@ -20,6 +20,9 @@ public partial class MigrateCallIdsToGuid : Migration
         // -----------------------------------------------------------------
 
         migrationBuilder.Sql("""
+            -- Ensure gen_random_uuid() is available (built-in since PG 13, pgcrypto fallback for older versions).
+            CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
             -- Step 1: Drop FK and indexes that depend on the old columns.
             ALTER TABLE call_participants DROP CONSTRAINT IF EXISTS fk_call_participants_calls_call_id;
             ALTER TABLE call_participants DROP CONSTRAINT IF EXISTS pk_call_participants;
@@ -80,8 +83,8 @@ public partial class MigrateCallIdsToGuid : Migration
 
     /// <inheritdoc />
     protected override void Down(MigrationBuilder migrationBuilder) {
-        // Reverse: convert uuid columns back to varchar(26) ULID strings.
-        // Note: original ULID values are lost; new string representations of UUIDs are used.
+        // Reverse: convert uuid columns back to varchar strings.
+        // Note: original ULID values are lost; UUID text representations (36 chars) are stored instead.
         migrationBuilder.Sql("""
             ALTER TABLE call_participants DROP CONSTRAINT IF EXISTS fk_call_participants_calls_call_id;
             ALTER TABLE call_participants DROP CONSTRAINT IF EXISTS pk_call_participants;
@@ -91,15 +94,15 @@ public partial class MigrateCallIdsToGuid : Migration
             DROP INDEX IF EXISTS ix_call_participants_user_id;
             DROP INDEX IF EXISTS ix_call_participants_user_id_status;
 
-            ALTER TABLE calls ADD COLUMN old_id character varying(26);
-            UPDATE calls SET old_id = SUBSTRING(id::text, 1, 26);
+            ALTER TABLE calls ADD COLUMN old_id character varying(36);
+            UPDATE calls SET old_id = id::text;
             ALTER TABLE calls ALTER COLUMN old_id SET NOT NULL;
 
-            ALTER TABLE call_participants ADD COLUMN old_id character varying(26);
-            UPDATE call_participants SET old_id = SUBSTRING(id::text, 1, 26);
+            ALTER TABLE call_participants ADD COLUMN old_id character varying(36);
+            UPDATE call_participants SET old_id = id::text;
             ALTER TABLE call_participants ALTER COLUMN old_id SET NOT NULL;
 
-            ALTER TABLE call_participants ADD COLUMN old_call_id character varying(26);
+            ALTER TABLE call_participants ADD COLUMN old_call_id character varying(36);
             UPDATE call_participants cp
             SET old_call_id = c.old_id
             FROM calls c

--- a/backend/Eternity.Infrastructure/Migrations/20260413210852_MigrateCallIdsToGuid.cs
+++ b/backend/Eternity.Infrastructure/Migrations/20260413210852_MigrateCallIdsToGuid.cs
@@ -1,0 +1,130 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Eternity.Infrastructure.Migrations;
+
+/// <inheritdoc />
+public partial class MigrateCallIdsToGuid : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder) {
+        // -----------------------------------------------------------------
+        // Data migration: convert ULID string IDs (varchar 26) to UUIDs.
+        // Strategy:
+        //   1. Drop all FK constraints and indexes that reference the old columns.
+        //   2. Add temporary uuid columns with generated values.
+        //   3. Map call_participants.call_id via a join on the old ULID value.
+        //   4. Drop old varchar columns, rename uuid columns to the original names.
+        //   5. Recreate primary keys, foreign keys, and indexes.
+        // -----------------------------------------------------------------
+
+        migrationBuilder.Sql("""
+            -- Step 1: Drop FK and indexes that depend on the old columns.
+            ALTER TABLE call_participants DROP CONSTRAINT IF EXISTS fk_call_participants_calls_call_id;
+            ALTER TABLE call_participants DROP CONSTRAINT IF EXISTS pk_call_participants;
+            ALTER TABLE calls            DROP CONSTRAINT IF EXISTS pk_calls;
+
+            DROP INDEX IF EXISTS ix_call_participants_call_id_user_id;
+            DROP INDEX IF EXISTS ix_call_participants_user_id;
+            DROP INDEX IF EXISTS ix_call_participants_user_id_status;
+
+            -- Step 2a: calls – add new uuid id column.
+            ALTER TABLE calls ADD COLUMN new_id uuid NOT NULL DEFAULT gen_random_uuid();
+            UPDATE calls SET new_id = gen_random_uuid();
+            ALTER TABLE calls ALTER COLUMN new_id DROP DEFAULT;
+
+            -- Step 2b: call_participants – add new uuid id & call_id columns.
+            ALTER TABLE call_participants ADD COLUMN new_id uuid NOT NULL DEFAULT gen_random_uuid();
+            UPDATE call_participants SET new_id = gen_random_uuid();
+            ALTER TABLE call_participants ALTER COLUMN new_id DROP DEFAULT;
+
+            ALTER TABLE call_participants ADD COLUMN new_call_id uuid;
+
+            -- Step 3: Map call_participants.new_call_id via old ULID FK.
+            UPDATE call_participants cp
+            SET new_call_id = c.new_id
+            FROM calls c
+            WHERE cp.call_id = c.id;
+
+            ALTER TABLE call_participants ALTER COLUMN new_call_id SET NOT NULL;
+
+            -- Step 4a: Drop old varchar columns.
+            ALTER TABLE call_participants DROP COLUMN call_id;
+            ALTER TABLE call_participants DROP COLUMN id;
+            ALTER TABLE calls DROP COLUMN id;
+
+            -- Step 4b: Rename new columns.
+            ALTER TABLE calls RENAME COLUMN new_id TO id;
+            ALTER TABLE call_participants RENAME COLUMN new_id TO id;
+            ALTER TABLE call_participants RENAME COLUMN new_call_id TO call_id;
+
+            -- Step 5: Recreate constraints and indexes.
+            ALTER TABLE calls ADD CONSTRAINT pk_calls PRIMARY KEY (id);
+
+            ALTER TABLE call_participants ADD CONSTRAINT pk_call_participants PRIMARY KEY (id);
+
+            ALTER TABLE call_participants ADD CONSTRAINT fk_call_participants_calls_call_id
+                FOREIGN KEY (call_id) REFERENCES calls(id) ON DELETE CASCADE;
+
+            CREATE UNIQUE INDEX ix_call_participants_call_id_user_id
+                ON call_participants (call_id, user_id);
+
+            CREATE INDEX ix_call_participants_user_id
+                ON call_participants (user_id);
+
+            CREATE INDEX ix_call_participants_user_id_status
+                ON call_participants (user_id, status);
+            """);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder) {
+        // Reverse: convert uuid columns back to varchar(26) ULID strings.
+        // Note: original ULID values are lost; new string representations of UUIDs are used.
+        migrationBuilder.Sql("""
+            ALTER TABLE call_participants DROP CONSTRAINT IF EXISTS fk_call_participants_calls_call_id;
+            ALTER TABLE call_participants DROP CONSTRAINT IF EXISTS pk_call_participants;
+            ALTER TABLE calls            DROP CONSTRAINT IF EXISTS pk_calls;
+
+            DROP INDEX IF EXISTS ix_call_participants_call_id_user_id;
+            DROP INDEX IF EXISTS ix_call_participants_user_id;
+            DROP INDEX IF EXISTS ix_call_participants_user_id_status;
+
+            ALTER TABLE calls ADD COLUMN old_id character varying(26);
+            UPDATE calls SET old_id = SUBSTRING(id::text, 1, 26);
+            ALTER TABLE calls ALTER COLUMN old_id SET NOT NULL;
+
+            ALTER TABLE call_participants ADD COLUMN old_id character varying(26);
+            UPDATE call_participants SET old_id = SUBSTRING(id::text, 1, 26);
+            ALTER TABLE call_participants ALTER COLUMN old_id SET NOT NULL;
+
+            ALTER TABLE call_participants ADD COLUMN old_call_id character varying(26);
+            UPDATE call_participants cp
+            SET old_call_id = c.old_id
+            FROM calls c
+            WHERE cp.call_id = c.id;
+            ALTER TABLE call_participants ALTER COLUMN old_call_id SET NOT NULL;
+
+            ALTER TABLE call_participants DROP COLUMN call_id;
+            ALTER TABLE call_participants DROP COLUMN id;
+            ALTER TABLE calls DROP COLUMN id;
+
+            ALTER TABLE calls RENAME COLUMN old_id TO id;
+            ALTER TABLE call_participants RENAME COLUMN old_id TO id;
+            ALTER TABLE call_participants RENAME COLUMN old_call_id TO call_id;
+
+            ALTER TABLE calls ADD CONSTRAINT pk_calls PRIMARY KEY (id);
+            ALTER TABLE call_participants ADD CONSTRAINT pk_call_participants PRIMARY KEY (id);
+            ALTER TABLE call_participants ADD CONSTRAINT fk_call_participants_calls_call_id
+                FOREIGN KEY (call_id) REFERENCES calls(id) ON DELETE CASCADE;
+
+            CREATE UNIQUE INDEX ix_call_participants_call_id_user_id
+                ON call_participants (call_id, user_id);
+            CREATE INDEX ix_call_participants_user_id
+                ON call_participants (user_id);
+            CREATE INDEX ix_call_participants_user_id_status
+                ON call_participants (user_id, status);
+            """);
+    }
+}

--- a/backend/Eternity.WebApi/Endpoints/CallsEndpoint.cs
+++ b/backend/Eternity.WebApi/Endpoints/CallsEndpoint.cs
@@ -39,7 +39,7 @@ public class CallsEndpoint : EndpointGroupBase
         return Results.Ok(result);
     }
 
-    private static async Task<IResult> DeclineCall(string callId, IMediator mediator, ICallNotifier callNotifier,
+    private static async Task<IResult> DeclineCall(Guid callId, IMediator mediator, ICallNotifier callNotifier,
         ICurrentUser currentUser) {
         var result = await mediator.Send(new DeclineCallCommand(callId));
         if (!result.Succeeded) {
@@ -58,7 +58,7 @@ public class CallsEndpoint : EndpointGroupBase
         return Results.Ok(result);
     }
 
-    private static async Task<IResult> GetCall(string callId, IMediator mediator) {
+    private static async Task<IResult> GetCall(Guid callId, IMediator mediator) {
         var result = await mediator.Send(new GetCallQuery(callId));
         return Results.Ok(result);
     }

--- a/backend/Eternity.WebApi/Hubs/CallHub.cs
+++ b/backend/Eternity.WebApi/Hubs/CallHub.cs
@@ -18,7 +18,7 @@ public partial class CallHub(
     ///     Called by the client after connecting to join a specific call room.
     ///     Enforces one-active-call-per-session at the hub level, then delegates to JoinCallCommand.
     /// </summary>
-    public async Task JoinCall(string callId) {
+    public async Task JoinCall(Guid callId) {
         if (!currentUser.IsAvailable) {
             await Clients.Caller.SendAsync("CallError", "Unauthorized.");
             return;
@@ -82,7 +82,7 @@ public partial class CallHub(
     /// <summary>
     ///     Client registers its PeerJS peer ID so other participants can establish WebRTC connections.
     /// </summary>
-    public async Task RegisterPeerId(string callId, string peerId) {
+    public async Task RegisterPeerId(Guid callId, string peerId) {
         if (!currentUser.IsAvailable) {
             return;
         }
@@ -97,7 +97,7 @@ public partial class CallHub(
     /// <summary>
     ///     Client broadcasts a change in their media state (mic/camera toggle) to all other participants.
     /// </summary>
-    public async Task NotifyMediaStateChanged(string callId, bool audioEnabled, bool videoEnabled) {
+    public async Task NotifyMediaStateChanged(Guid callId, bool audioEnabled, bool videoEnabled) {
         if (!currentUser.IsAvailable) {
             return;
         }
@@ -112,7 +112,7 @@ public partial class CallHub(
     ///     Client explicitly leaves a call room.
     ///     Only triggers domain-level Leave if no other session of this user is in the call.
     /// </summary>
-    public async Task LeaveCall(string callId) {
+    public async Task LeaveCall(Guid callId) {
         if (!currentUser.IsAvailable) {
             return;
         }
@@ -142,7 +142,7 @@ public partial class CallHub(
     ///     Send a WebRTC signaling message to a specific user in the call.
     ///     Currently unused (PeerJS handles its own signaling), but kept as a fallback mechanism.
     /// </summary>
-    public async Task SendSignal(string callId, Guid targetUserId, object signal) {
+    public async Task SendSignal(Guid callId, Guid targetUserId, object signal) {
         if (!currentUser.IsAvailable) {
             return;
         }
@@ -162,21 +162,22 @@ public partial class CallHub(
             var sessionKey = callConnectionTracker.GetSessionKeyByConnection(Context.ConnectionId);
             var callId = callConnectionTracker.GetCallIdByConnection(Context.ConnectionId);
             if (callId != null && sessionKey != null) {
+                var cid = callId.Value;
                 var userId = sessionKey.UserId;
                 var sessionId = sessionKey.SessionId;
-                var callGroup = CallConnectionTracker.GetCallGroup(callId);
-                callConnectionTracker.RemoveSessionFromCall(callId, userId, sessionId, Context.ConnectionId);
+                var callGroup = CallConnectionTracker.GetCallGroup(cid);
+                callConnectionTracker.RemoveSessionFromCall(cid, userId, sessionId, Context.ConnectionId);
                 await Groups.RemoveFromGroupAsync(Context.ConnectionId, callGroup);
-                if (!callConnectionTracker.IsUserInCall(callId, userId)) {
-                    var result = await mediator.Send(new LeaveCallCommand(callId));
-                    await Clients.Group(callGroup).SendAsync("ParticipantLeft", new { callId, userId });
+                if (!callConnectionTracker.IsUserInCall(cid, userId)) {
+                    var result = await mediator.Send(new LeaveCallCommand(cid));
+                    await Clients.Group(callGroup).SendAsync("ParticipantLeft", new { callId = cid, userId });
                     if (result.Succeeded && result.Data.CallEnded) {
                         await Clients.Group(callGroup)
                             .SendAsync("CallEnded",
-                                new { callId, reason = "All participants disconnected." });
+                                new { callId = cid, reason = "All participants disconnected." });
                     }
                 }
-                LogUserDisconnectedFromCall(logger, userId, sessionId, callId);
+                LogUserDisconnectedFromCall(logger, userId, sessionId, cid);
             }
         }
         await base.OnDisconnectedAsync(exception);
@@ -184,18 +185,18 @@ public partial class CallHub(
 
     [LoggerMessage(Level = LogLevel.Information,
         Message = "User {UserId} (session {SessionId}) joined call {CallId}, connection {ConnectionId}")]
-    private static partial void LogUserJoinedCall(ILogger logger, Guid userId, Guid sessionId, string callId,
+    private static partial void LogUserJoinedCall(ILogger logger, Guid userId, Guid sessionId, Guid callId,
         string connectionId);
 
     [LoggerMessage(Level = LogLevel.Information,
         Message = "User {UserId} registered peerId {PeerId} in call {CallId}")]
-    private static partial void LogPeerIdRegistered(ILogger logger, Guid userId, string peerId, string callId);
+    private static partial void LogPeerIdRegistered(ILogger logger, Guid userId, string peerId, Guid callId);
 
     [LoggerMessage(Level = LogLevel.Information,
         Message = "User {UserId} (session {SessionId}) left call {CallId}")]
-    private static partial void LogUserLeftCall(ILogger logger, Guid userId, Guid sessionId, string callId);
+    private static partial void LogUserLeftCall(ILogger logger, Guid userId, Guid sessionId, Guid callId);
 
     [LoggerMessage(Level = LogLevel.Information,
         Message = "User {UserId} (session {SessionId}) disconnected from call {CallId}")]
-    private static partial void LogUserDisconnectedFromCall(ILogger logger, Guid userId, Guid sessionId, string callId);
+    private static partial void LogUserDisconnectedFromCall(ILogger logger, Guid userId, Guid sessionId, Guid callId);
 }

--- a/backend/Eternity.WebApi/Services/CallConnectionTracker.cs
+++ b/backend/Eternity.WebApi/Services/CallConnectionTracker.cs
@@ -12,13 +12,13 @@ public class CallConnectionTracker
     /// <summary>
     ///     callId → { (userId, sessionId) → connection info }
     /// </summary>
-    private readonly ConcurrentDictionary<string, ConcurrentDictionary<CallSessionKey, CallSessionConnection>>
+    private readonly ConcurrentDictionary<Guid, ConcurrentDictionary<CallSessionKey, CallSessionConnection>>
         _callSessions = new();
 
     /// <summary>
     ///     connectionId → callId (for OnDisconnectedAsync lookup)
     /// </summary>
-    private readonly ConcurrentDictionary<string, string> _connectionToCall = new();
+    private readonly ConcurrentDictionary<string, Guid> _connectionToCall = new();
 
     /// <summary>
     ///     connectionId → (userId, sessionId) (for OnDisconnectedAsync lookup)
@@ -27,7 +27,7 @@ public class CallConnectionTracker
 
     private readonly Lock _lock = new();
 
-    public void AddSessionToCall(string callId, Guid userId, Guid sessionId, string connectionId) {
+    public void AddSessionToCall(Guid callId, Guid userId, Guid sessionId, string connectionId) {
         lock (_lock) {
             var sessions = _callSessions.GetOrAdd(
                 callId,
@@ -40,7 +40,7 @@ public class CallConnectionTracker
         }
     }
 
-    public void RemoveSessionFromCall(string callId, Guid userId, Guid sessionId, string connectionId) {
+    public void RemoveSessionFromCall(Guid callId, Guid userId, Guid sessionId, string connectionId) {
         lock (_lock) {
             var key = new CallSessionKey(userId, sessionId);
             if (_callSessions.TryGetValue(callId, out var sessions)) {
@@ -54,7 +54,7 @@ public class CallConnectionTracker
         }
     }
 
-    public void SetPeerId(string callId, Guid userId, Guid sessionId, string peerId) {
+    public void SetPeerId(Guid callId, Guid userId, Guid sessionId, string peerId) {
         lock (_lock) {
             var key = new CallSessionKey(userId, sessionId);
             if (_callSessions.TryGetValue(callId, out var sessions) && sessions.TryGetValue(key, out var connection)) {
@@ -63,7 +63,7 @@ public class CallConnectionTracker
         }
     }
 
-    public void SetMediaState(string callId, Guid userId, Guid sessionId, bool audioEnabled, bool videoEnabled) {
+    public void SetMediaState(Guid callId, Guid userId, Guid sessionId, bool audioEnabled, bool videoEnabled) {
         lock (_lock) {
             var key = new CallSessionKey(userId, sessionId);
             if (_callSessions.TryGetValue(callId, out var sessions) && sessions.TryGetValue(key, out var connection)) {
@@ -75,9 +75,8 @@ public class CallConnectionTracker
     /// <summary>
     ///     Look up which call a given connectionId is associated with.
     /// </summary>
-    public string? GetCallIdByConnection(string connectionId) {
-        _connectionToCall.TryGetValue(connectionId, out var callId);
-        return callId;
+    public Guid? GetCallIdByConnection(string connectionId) {
+        return _connectionToCall.TryGetValue(connectionId, out var callId) ? callId : null;
     }
 
     /// <summary>
@@ -91,7 +90,7 @@ public class CallConnectionTracker
     /// <summary>
     ///     Get all distinct user IDs in a call (across all sessions).
     /// </summary>
-    public List<Guid> GetUsersInCall(string callId) {
+    public List<Guid> GetUsersInCall(Guid callId) {
         lock (_lock) {
             if (_callSessions.TryGetValue(callId, out var sessions)) {
                 return sessions.Keys.Select(k => k.UserId).Distinct().ToList();
@@ -114,7 +113,7 @@ public class CallConnectionTracker
     /// <summary>
     ///     Check if a specific session is in a specific call.
     /// </summary>
-    public bool IsSessionInCall(string callId, Guid userId, Guid sessionId) {
+    public bool IsSessionInCall(Guid callId, Guid userId, Guid sessionId) {
         lock (_lock) {
             var key = new CallSessionKey(userId, sessionId);
             return _callSessions.TryGetValue(callId, out var sessions) && sessions.ContainsKey(key);
@@ -125,7 +124,7 @@ public class CallConnectionTracker
     ///     Get the connectionId for a specific session in a specific call.
     ///     Returns null if the session is not in the call.
     /// </summary>
-    public string? GetConnectionIdForSession(string callId, Guid userId, Guid sessionId) {
+    public string? GetConnectionIdForSession(Guid callId, Guid userId, Guid sessionId) {
         lock (_lock) {
             var key = new CallSessionKey(userId, sessionId);
             if (_callSessions.TryGetValue(callId, out var sessions) && sessions.TryGetValue(key, out var connection)) {
@@ -140,13 +139,13 @@ public class CallConnectionTracker
     ///     Used to decide whether the domain-level Leave should be called
     ///     (only when the last session of a user disconnects from a call).
     /// </summary>
-    public bool IsUserInCall(string callId, Guid userId) {
+    public bool IsUserInCall(Guid callId, Guid userId) {
         lock (_lock) {
             return _callSessions.TryGetValue(callId, out var sessions) && sessions.Keys.Any(k => k.UserId == userId);
         }
     }
 
-    public static string GetCallGroup(string callId) {
+    public static string GetCallGroup(Guid callId) {
         return $"call_{callId}";
     }
 
@@ -154,7 +153,7 @@ public class CallConnectionTracker
     ///     Returns all connection IDs for a specific user in a given call (across all their sessions).
     ///     Used to send targeted signaling messages to a specific participant.
     /// </summary>
-    public List<string> GetConnectionIdsForUser(string callId, Guid userId) {
+    public List<string> GetConnectionIdsForUser(Guid callId, Guid userId) {
         lock (_lock) {
             if (!_callSessions.TryGetValue(callId, out var sessions)) {
                 return [];
@@ -167,7 +166,7 @@ public class CallConnectionTracker
     ///     Returns all existing peer registrations in a call, excluding a specific user.
     ///     Used to send existing peers to a newly joined participant so they can initiate calls.
     /// </summary>
-    public List<(Guid UserId, string PeerId)> GetExistingPeerRegistrations(string callId, Guid excludeUserId) {
+    public List<(Guid UserId, string PeerId)> GetExistingPeerRegistrations(Guid callId, Guid excludeUserId) {
         lock (_lock) {
             if (!_callSessions.TryGetValue(callId, out var sessions)) {
                 return [];
@@ -182,7 +181,7 @@ public class CallConnectionTracker
     ///     Returns the current media state for all participants in a call, excluding a specific user.
     ///     Used to send existing media states to a newly joined participant.
     /// </summary>
-    public List<(Guid UserId, bool AudioEnabled, bool VideoEnabled)> GetExistingMediaStates(string callId,
+    public List<(Guid UserId, bool AudioEnabled, bool VideoEnabled)> GetExistingMediaStates(Guid callId,
         Guid excludeUserId) {
         lock (_lock) {
             if (!_callSessions.TryGetValue(callId, out var sessions)) {

--- a/backend/Eternity.WebApi/Services/CallNotifier.cs
+++ b/backend/Eternity.WebApi/Services/CallNotifier.cs
@@ -18,7 +18,7 @@ public partial class CallNotifier(
     IAppDbContext dbContext,
     ILogger<CallNotifier> logger) : ICallNotifier
 {
-    public async Task NotifyIncomingCallAsync(string callId, CallParticipantDto initiator, CallType callType,
+    public async Task NotifyIncomingCallAsync(Guid callId, CallParticipantDto initiator, CallType callType,
         List<CallParticipantDto> participants, List<Guid> inviteeUserIds) {
         var notification = new {
             callId,
@@ -49,20 +49,20 @@ public partial class CallNotifier(
         LogIncomingCallNotification(logger, callId, sessionIds.Count, inviteeUserIds.Count);
     }
 
-    public async Task NotifyParticipantJoinedAsync(string callId, Guid userId, string username, string fullName) {
+    public async Task NotifyParticipantJoinedAsync(Guid callId, Guid userId, string username, string fullName) {
         var callGroup = CallConnectionTracker.GetCallGroup(callId);
         await callHubContext.Clients.Group(callGroup)
             .SendAsync("ParticipantJoined", new { callId, userId, username, fullName });
         LogParticipantJoined(logger, callId, userId);
     }
 
-    public async Task NotifyParticipantLeftAsync(string callId, Guid userId) {
+    public async Task NotifyParticipantLeftAsync(Guid callId, Guid userId) {
         var callGroup = CallConnectionTracker.GetCallGroup(callId);
         await callHubContext.Clients.Group(callGroup).SendAsync("ParticipantLeft", new { callId, userId });
         LogParticipantLeft(logger, callId, userId);
     }
 
-    public async Task NotifyCallDeclinedAsync(string callId, Guid userId) {
+    public async Task NotifyCallDeclinedAsync(Guid callId, Guid userId) {
         var callGroup = CallConnectionTracker.GetCallGroup(callId);
         await callHubContext.Clients.Group(callGroup).SendAsync("ParticipantDeclined", new { callId, userId });
         var initiatorId = await dbContext.Calls.AsNoTracking()
@@ -83,7 +83,7 @@ public partial class CallNotifier(
         LogCallDeclined(logger, userId, callId);
     }
 
-    public async Task NotifyCallEndedAsync(string callId, string reason, List<Guid> participantUserIds) {
+    public async Task NotifyCallEndedAsync(Guid callId, string reason, List<Guid> participantUserIds) {
         var payload = new { callId, reason };
         var callGroup = CallConnectionTracker.GetCallGroup(callId);
         await callHubContext.Clients.Group(callGroup).SendAsync("CallEnded", payload);
@@ -100,18 +100,18 @@ public partial class CallNotifier(
 
     [LoggerMessage(Level = LogLevel.Information,
         Message = "Sent incoming call notification for call {CallId} to {Count} session(s) of {UserCount} invitee(s)")]
-    private static partial void LogIncomingCallNotification(ILogger logger, string callId, int count, int userCount);
+    private static partial void LogIncomingCallNotification(ILogger logger, Guid callId, int count, int userCount);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Notified call {CallId} that user {UserId} joined")]
-    private static partial void LogParticipantJoined(ILogger logger, string callId, Guid userId);
+    private static partial void LogParticipantJoined(ILogger logger, Guid callId, Guid userId);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Notified call {CallId} that user {UserId} left")]
-    private static partial void LogParticipantLeft(ILogger logger, string callId, Guid userId);
+    private static partial void LogParticipantLeft(ILogger logger, Guid callId, Guid userId);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "Notified that user {UserId} declined call {CallId}")]
-    private static partial void LogCallDeclined(ILogger logger, Guid userId, string callId);
+    private static partial void LogCallDeclined(ILogger logger, Guid userId, Guid callId);
 
     [LoggerMessage(Level = LogLevel.Information,
         Message = "Notified all participants that call {CallId} ended: {Reason}")]
-    private static partial void LogCallEnded(ILogger logger, string callId, string reason);
+    private static partial void LogCallEnded(ILogger logger, Guid callId, string reason);
 }

--- a/frontend/src/app/core/services/peer.service.ts
+++ b/frontend/src/app/core/services/peer.service.ts
@@ -132,6 +132,7 @@ export class PeerService implements OnDestroy {
     }
 
     if (this.peer) {
+      this.peer.removeAllListeners();
       this.peer.destroy();
       this.peer = null;
     }

--- a/frontend/src/app/features/call-history/call-history.html
+++ b/frontend/src/app/features/call-history/call-history.html
@@ -82,4 +82,6 @@
   </section>
 </div>
 
-<app-new-call-modal />
+@if (store.newCallModalVisible()) {
+  <app-new-call-modal />
+}

--- a/frontend/src/app/shared/components/incoming-call-handler/incoming-call-handler.html
+++ b/frontend/src/app/shared/components/incoming-call-handler/incoming-call-handler.html
@@ -1,5 +1,5 @@
 <p-toast key="incoming-call" position="top-right" [life]="30000">
-  <ng-template #headless let-message>
+  <ng-template #headless let-message let-closeFn="closeFn">
     <div class="bg-foreground border-surface flex w-80 flex-col gap-3 rounded-xl border p-4 shadow-lg">
       <div class="flex items-center gap-3">
         <div class="relative">
@@ -20,14 +20,14 @@
         <button
           type="button"
           class="flex h-9 grow cursor-pointer items-center justify-center gap-2 rounded-lg bg-rose-500 px-3 text-sm font-medium text-white hover:bg-rose-600"
-          (click)="onDecline()">
+          (click)="onDecline($event, closeFn)">
           <lucide-icon [img]="phoneOffIcon" class="h-4 w-4"></lucide-icon>
           Decline
         </button>
         <button
           type="button"
           class="bg-primary text-primary-contrast flex h-9 grow cursor-pointer items-center justify-center gap-2 rounded-lg px-3 text-sm font-medium hover:brightness-110"
-          (click)="onAccept()">
+          (click)="onAccept($event, closeFn)">
           <lucide-icon [img]="phoneIcon" class="h-4 w-4"></lucide-icon>
           Accept
         </button>

--- a/frontend/src/app/shared/components/incoming-call-handler/incoming-call-handler.ts
+++ b/frontend/src/app/shared/components/incoming-call-handler/incoming-call-handler.ts
@@ -21,11 +21,13 @@ export class IncomingCallHandler {
   readonly phoneIcon = Phone;
   readonly phoneOffIcon = PhoneOff;
 
-  onAccept(): void {
+  onAccept(event: Event, closeFn: (event: Event) => void): void {
+    closeFn(event);
     this.incomingCallService.openPreJoin();
   }
 
-  onDecline(): void {
+  onDecline(event: Event, closeFn: (event: Event) => void): void {
+    closeFn(event);
     this.incomingCallService.declineCall();
   }
 }


### PR DESCRIPTION
## Summary

Fixes multiple issues with call functionality across frontend and backend:

- **Incoming call popup stays open**: The Accept/Decline buttons now use PrimeNG's headless `closeFn(event)` to properly dismiss the toast notification.
- **PeerJS WebSocket leak**: `removeAllListeners()` is called before `destroy()` in `PeerService` to prevent the `disconnected` handler from triggering a reconnect during intentional teardown.
- **ULID-to-Guid migration**: All `Call` and `CallParticipant` IDs migrated from ULID (`varchar(26)`) to native PostgreSQL `uuid` type across Domain, Application, Infrastructure, and WebApi layers. The `Ulid` NuGet package is removed.
- **Data migration**: An EF Core migration with raw SQL converts existing ULID string IDs to new UUIDs while preserving FK integrity. Safe as a no-op on fresh/empty databases.
- **Eager user search**: `<app-new-call-modal>` is now conditionally rendered (`@if`) so `api/users/search` is only called when the modal actually opens, not on page load.

### Files changed: 22 (20 modified, 2 new migration files)

Closes #48