### PR TITLE
docs(readme): describe product vision and architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,63 @@
-# eternity
+# Eternity
 
-Repository guidance for AI coding agents now lives in:
+## Expected product vision
 
-- `AGENTS.md`
-- `frontend/AGENTS.md`
-- `backend/AGENTS.md`
-- `.agents/skills/`
-- `docs/`
+Eternity is a privately deployed platform for one organization, team, or community. Each group runs its own instance, invites its own users, and shapes the system around its own processes instead of joining a shared public product.
 
-Useful docs:
+The target product combines two layers in one place:
 
-- `docs/architecture.md`
-- `docs/features/`
-- `docs/skills-policy.md`
-- `docs/tooling-policy.md`
+- ready-made core features for everyday work, such as authentication, sessions, calls, chat, feed, calendar, and org structure
+- design tools that let admins create custom sections, pages, entities, process flows, and AI-assisted automations for their own instance
+- one runtime where built-in features and designed features live together for the same users and the same data
 
-This repo uses a simplified layout optimized for OpenCode:
+The goal is to let a business, team, or private group start with useful built-in collaboration features and then extend the same system with design tools that match how they actually operate.
 
-- shared repo rules in `AGENTS.md`
-- native OpenCode task skills in `.agents/skills/`
-- architecture, feature, and policy docs in `docs/`
+## Architecture
+
+Current runtime foundation:
+
+- core backend: .NET 10 application for auth, built-in features, real-time coordination, and runtime APIs
+- core frontend: Angular 21 application for the main user-facing experience
+- database: PostgreSQL
+- live communication: SignalR and PeerJS for the current calling flow
+
+Planned expansion:
+
+- the core service remains the single auth system and the runtime host for both built-in and designed functionality
+- a design backend is planned for managing design-time definitions for custom pages, entities, flows, and agents
+- a design frontend is planned as the visual builder for admins
+- a separate Node.js flow executor is planned for scriptable workflow execution while still using the core runtime APIs
+- designed UI is expected to be stored as parsable JSON so the core UI can render it at runtime
+- built-in and designed data are expected to converge behind the same core runtime entity layer over time
+
+Target public routing:
+
+- `/dashboard/...` for the core user experience and runtime-rendered pages
+- `/design/...` for the design system used by admins
+
+```mermaid
+flowchart LR
+  Users --> CoreUI["Core UI (Angular)\n/dashboard and runtime pages"]
+  Admins --> DesignUI["Design UI (planned)\n/design"]
+  CoreUI --> CoreBackend["Core Backend (.NET)\nauth, built-in features, runtime APIs"]
+  DesignUI --> DesignBackend["Design Backend (planned, Node.js)\ndesign-time definitions"]
+  DesignBackend --> FlowExecutor["Flow Executor (planned, Node.js)\nscriptable workflows"]
+  DesignBackend --> CoreBackend
+  FlowExecutor --> CoreBackend
+  CoreBackend --> Postgres["PostgreSQL"]
+```
+
+## Built-in features already implemented
+
+- authentication with cookie-based JWT sessions and persisted session records
+- public registration requests with admin approval or rejection
+- admin management for registration requests and user sessions
+- session visibility and controls for online, active, and inactive sessions, including terminate and ping actions
+- audio and video calls with call history, incoming call handling
+- authenticated application shell with a profile page and role-aware frontend/backend boundaries
+
+Near-term direction:
+
+- expand the built-in collaboration surface from the current core
+- introduce the separate design-time services
+- start rendering designed pages, flows, and runtime-managed entities inside the core experience

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ At runtime, the frontend communicates with the backend through the server's publ
 
 ## Frontend Architecture
 
-- The frontend is an Angular 20 standalone application.
+- The frontend is an Angular 21 standalone application.
 - App-wide providers are configured in `frontend/src/app/app.config.ts`.
 - Routes are centralized in `frontend/src/app/app.routes.ts`.
 - `core/` contains app-wide infrastructure, theme, HTTP, and shared client integrations.
@@ -27,7 +27,7 @@ This structure keeps cross-cutting concerns centralized while allowing user-faci
 
 ## Backend Architecture
 
-The backend is a .NET 9 solution split into four layers:
+The backend is a .NET 10 solution split into four layers:
 
 - `Eternity.WebApi` handles HTTP transport, endpoint groups, hubs, and web-facing services.
 - `Eternity.Application` contains commands, queries, validators, DTOs, and application-layer interfaces.

--- a/docs/backend-formatting.md
+++ b/docs/backend-formatting.md
@@ -47,9 +47,9 @@ dotnet format Eternity.sln
 
 ## Analyzer Baseline
 
-- The backend uses the analyzers built into the .NET 9 SDK.
+- The backend uses the analyzers built into the .NET 10 SDK.
 - No `Microsoft.CodeAnalysis.NetAnalyzers` package is required.
-- `AnalysisLevel` is pinned to `9-recommended` for stable CI behavior.
+- `AnalysisLevel` is pinned to `10-recommended` for stable CI behavior.
 - `EnforceCodeStyleInBuild` is enabled so practical style diagnostics are visible during build.
 
 ## Migrations

--- a/docs/tooling-policy.md
+++ b/docs/tooling-policy.md
@@ -41,9 +41,9 @@ This document explains when AI agents working in this repository should rely on 
 
 ### Good use cases
 
-- Angular 20 framework details not already shown in repo code
+- Angular 21 framework details not already shown in repo code
 - PrimeNG API details not obvious from local usage
-- .NET 9 or EF Core API questions where repo examples are insufficient
+- .NET 10 or EF Core API questions where repo examples are insufficient
 - upgrade or compatibility work
 
 ### Avoid when


### PR DESCRIPTION
## Summary
- replace the root README with a concise product-facing overview of Eternity's vision, planned architecture, and current built-in features
- clarify the planned split between the core runtime and future design-time services, including the target `/dashboard` and `/design` routes
- align related docs with the repo's current Angular 21 and .NET 10 versions

Closes #52